### PR TITLE
플레이어 회전 문제 및 isGrounded 처리 버그 수정

### DIFF
--- a/Assets/Scripts/Player/State/IdleState.cs
+++ b/Assets/Scripts/Player/State/IdleState.cs
@@ -7,10 +7,10 @@ public class IdleState : State<PlayerController>
 
     public override void Enter(PlayerController player)
     {
+        player.anim.SetBool("grounded", player.isGrounded);
         player.anim.SetInteger("up", 4);
         player.anim.SetFloat("walk", 0);
-
-        // 카메라의 위치를 캐릭터 뒤로 설정
+                
         if (player.cameraController != null)
         {
             player.cameraController.SetIdleCameraOffset(cameraOffset, cameraRotationOffset);            


### PR DESCRIPTION
## 개요:
#28  플레이어 이동 후 회전값이 초기화되고, 공중에 떠 있는 문제가 발생하여 이를 수정.

## 주요 변경 사항:
- `RotateCharacter()` 메서드에서 이동 후에도 마지막 이동 방향을 유지하도록 수정.
- `isGrounded` 처리를 `OnCollisionStay`와 `OnCollisionExit` 방식으로 변경.
- `IdleState.cs`의 `Enter()` 메서드에서 `player.anim.SetBool("grounded", player.isGrounded);`를 호출하여 캐릭터가 공중에 뜨지 않도록 수정.

## 기대 효과:
- 플레이어가 이동 후 마지막으로 바라본 방향을 유지.
- `isGrounded` 처리 방식 개선으로 인해 캐릭터가 공중에 뜨지 않음.
- 플레이어의 자연스러운 회전과 애니메이션 동작 보장.